### PR TITLE
`lofitime` rewrite to use From<T> and Into<T> instead of custom traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "lofitime"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "hifitime",

--- a/lofitime/Cargo.toml
+++ b/lofitime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lofitime"
 description = "Handy translations between Hifitime and Chrono datetimes and durations."
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 edition.workspace = true
 

--- a/lofitime/README.md
+++ b/lofitime/README.md
@@ -1,0 +1,49 @@
+# lofitime
+
+`lofitime` is a Rust crate that provides wrapper types and conversion utilities
+for working with both high-precision (`hifitime`) and low-precision (`chrono`)
+time libraries. This crate aims to bridge the gap between these two popular
+time-handling libraries in the Rust ecosystem.
+
+## Features
+
+- Wrapper types for `hifitime::Epoch`, `hifitime::Duration`,
+  `chrono::DateTime<Utc>`, and `chrono::Duration`
+- Low-friction conversions between `hifitime` and `chrono` types
+- Implementation of common traits like `Deref`, `DerefMut`, and `Timelike` for
+  wrapper types
+- Simplified `SimpleDateLike` trait for common date operations
+
+## Todos
+- [ ] ✨Seamless✨ conversions between `hifitime` and `chrono` types
+- [ ] Upstream into `hifitime`?
+
+## Usage
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+lofitime = "0.2.0"
+```
+
+Then, you can use the wrapper types in your code:
+
+```rust
+use lofitime::{HifiEpoch, LofiDateTime};
+
+let hifi_epoch = HifiEpoch(hifitime::Epoch::from_gregorian_utc(2023, 8, 12, 15, 30, 45, 0));
+let lofi_datetime: LofiDateTime = hifi_epoch.into();
+
+assert_eq!(lofi_datetime.year(), 2023);
+assert_eq!(lofi_datetime.month(), 8);
+assert_eq!(lofi_datetime.day(), 12);
+```
+
+## Why use lofitime?
+
+- **Interoperability**: Easily convert between `hifitime` and `chrono` types.
+- **Simplified API**: Use a consistent interface for both high-precision and
+  low-precision time operations.
+- **Type Safety**: Wrapper types provide clear distinctions between different
+  time representations.

--- a/spacetime/src/ui/datetime.rs
+++ b/spacetime/src/ui/datetime.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use bevy_egui::egui::{self, Widget};
 use egui_extras::DatePickerButton;
 use hifitime::prelude::*;
-use lofitime::{HifiDateTime, LofiDateTime};
+use lofitime::{HifiEpoch, LofiDateTime};
 
 use crate::physics::time::CoordinateTime;
 
@@ -16,11 +16,15 @@ pub fn set_time_menu(ui: &mut egui::Ui, coordinate_time: &mut ResMut<CoordinateT
             });
         });
         ui.menu_button("Epoch...", |ui| {
-            let mut selected_date = coordinate_time.epoch().to_lofi_naive().date();
+            let hifi_epoch = HifiEpoch(coordinate_time.epoch());
+            let chrono_datetime: chrono::NaiveDateTime = hifi_epoch.into();
+            let mut selected_date = chrono_datetime.date();
             if DatePickerButton::new(&mut selected_date).ui(ui).changed() {
                 // Update the Time resource with the selected date
                 let new_time = selected_date.and_time(chrono::NaiveTime::from_hms_milli_opt(0, 0, 0, 0).unwrap());
-                coordinate_time.start_epoch = Some(new_time.and_utc().to_hifi_epoch());
+                let new_datetime = new_time.and_utc();
+                let lofi_datetime = LofiDateTime(new_datetime);
+                coordinate_time.start_epoch = Some(lofi_datetime.into());
             }
         });
     });


### PR DESCRIPTION
- Implements wrapper types for `hifitime::Epoch`, `hifitime::Duration`,
  `chrono::DateTime<Utc>`, and `chrono::Duration` instead of traits
- Low-friction conversions between `hifitime` and `chrono` types using `From<T>` and `Into<T>`
- Implementation of common traits like `Deref`, `DerefMut`, and `Timelike` for
  wrapper types
- Simplified `SimpleDateLike` trait for common date operations. (Honestly this is a crutch to avoid making a full `DateLike` implementation for the wrapper type.)
- Added a Readme.

# Example
Here's an example I'm using to adapt `hifitime::Epoch`s into egui's `DatePickerButton`, which only works with `chrono::NaiveDate`s.

In this case I don't care about the loss of precision. I want to use the button to select a date and then use this new date as the starting epoch for a precision timer. 
1. Wrap the `hifitime::Epoch` with `HifiEpoch` to enable simple type conversions to `chrono` types.
2. Convert the precision epoch to a loose timezone-naive `chrono::NaiveDateTime` with a simple `.into()`. This keeps precision up to `chrono`'s limits, which is in the millisecond range. Note that this is no longer inside a wrapper, it's an actual `chrono` type.
3. Manipulate the struct as a `chrono` type as if it were `chrono` all along.
4. Wrap the `chrono::DateTime` with `LofiDateTime` to enable simple type conversions back to `hifitime` types.
5. Use `.into()` to get the datetime back as a `hifitime::Epoch`. At this point the epoch only has the precision of `chrono` but from now on we can use it as a precision epoch with `hifitime` as if it were an epoch all along.

```rust
ui.menu_button("Epoch...", |ui| {
    let hifi_epoch = HifiEpoch(coordinate_time.epoch());
    let chrono_datetime: chrono::NaiveDateTime = hifi_epoch.into(); // convert precision epoch to timezone-aware `chrono::DateTime`
    let mut selected_date = chrono_datetime.date();
    if DatePickerButton::new(&mut selected_date).ui(ui).changed() {
        // Update the Time resource with the selected date
        let new_time = selected_date.and_time(chrono::NaiveTime::from_hms_milli_opt(0, 0, 0, 0).unwrap());
        let new_datetime = new_time.and_utc();
        let lofi_datetime = LofiDateTime(new_datetime);
        coordinate_time.start_epoch = Some(lofi_datetime.into()); // convert new date back to `hifitime::Epoch`
    }
});
```