### PR TITLE
tools: Bevy features and debug console

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,24 +6,24 @@ authors = ["Philip Linden <lindenphilipj@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-log = { version = "0.4.22", features = [
+log = { version = "0.4.25", features = [
     # Disable low-severity logs at compile time for performance.
     "max_level_debug",
     "release_max_level_warn",
 ] }
-hifitime = "4.0.1"
-thiserror = "2.0.7"
-bevy = { version = "0.15", default-features = false, features = [
-    "bevy_asset",
-    "bevy_state",
-    "bevy_window",
-    "multi_threaded",
-]}
+hifitime = "4.0.2"
+bevy = "0.15.1"
+bevy_console = { version = "0.13.1", optional = true }
+clap = { version = "4.5.27", optional = true }
 
 [features]
 default = ["dev"]
 dev = [
-    "bevy/dynamic_linking"
+    "bevy/dynamic_linking",
+    "bevy/bevy_dev_tools",
+    "bevy/bevy_debug_stepping",
+    "bevy_console",
+    "clap",
 ]
 
 # Idiomatic Bevy code often triggers these lints, and the CI workflow treats them as errors.
@@ -58,7 +58,7 @@ codegen-units = 1
 lto = "thin"
 # Optimize with size in mind (also try "z", sometimes it is better).
 # Slightly slows compile times, great improvements to file size and runtime performance.
-opt-level = "s"
+opt-level = "z"
 # Strip all debugging information from the binary to slightly reduce file size.
 strip = "debuginfo"
 

--- a/docs/dev/log/2025-01-06.md
+++ b/docs/dev/log/2025-01-06.md
@@ -1,0 +1,1 @@
+One interesting analogy for gravity is a conveyor belt. the belt is moving, but if you're on the belt you move with it unless acted on by a force.

--- a/docs/dev/log/2025-01-23.md
+++ b/docs/dev/log/2025-01-23.md
@@ -1,0 +1,3 @@
+An interesting concept is [timescapes](https://youtu.be/SXg6YVcdOcA) --- a model wherein the apparent expansion of the universe is a byproduct of time moving faster in open areas than areas with lots of matter.
+
+ [arXiv:gr-qc/0702082v4](https://arxiv.org/abs/gr-qc/0702082v4)

--- a/docs/src/relativity/general/00-index.md
+++ b/docs/src/relativity/general/00-index.md
@@ -52,11 +52,11 @@ following video does an excellent job of explaining it:
 
 Video: [Gravity comes from time curving space](https://youtu.be/OpOER8Eec2A)
 
-![alt text](/relativity/general/assets/image.png)
+![alt text](./assets/image.png)
 
-![alt text](/relativity/general/assets/image2.png)
+![alt text](./assets/image2.png)
 
-![alt text](/relativity/general/assets/image3.png)
+![alt text](./assets/image3.png)
 
 ## Curved spacetime
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,0 +1,15 @@
+use bevy::prelude::*;
+
+pub(super) fn plugin(app: &mut App) {
+    app.add_systems(Startup, setup_camera);
+}
+
+#[derive(Component)]
+struct ViewportCamera;
+
+fn setup_camera(mut commands: Commands) {
+    commands.spawn((
+        Camera3d::default(),
+        ViewportCamera,
+    ));
+}

--- a/src/dev/console.rs
+++ b/src/dev/console.rs
@@ -1,0 +1,87 @@
+use bevy::{
+    prelude::*,
+    log::{self, LogPlugin},
+};
+use bevy_console::{self, make_layer, AddConsoleCommand, ConsoleCommand, ConsoleConfiguration, ConsoleOpen};
+use clap::Parser;
+
+const OPEN_BY_DEFAULT: bool = false;
+
+pub(super) fn plugin(app: &mut App) {
+    app.add_plugins((
+        bevy_console::ConsolePlugin,
+        LogPlugin {
+            level: log::Level::INFO,
+            filter: "info,capture_bevy_logs=info".to_owned(),
+            custom_layer: make_layer,
+        }))
+        .insert_resource(ConsoleOpen {
+            open: OPEN_BY_DEFAULT,
+        })
+        .insert_resource(ConsoleConfiguration {
+            top_pos: 0.0,
+            left_pos: 5.0,
+            height: 500.0,
+            width: 1280.0,
+            show_title_bar: false,
+            ..Default::default()
+        });
+
+    // Add commands plugins
+    app.add_plugins((
+        SpawnCommandsPlugin,
+    ));
+}
+
+struct SpawnCommandsPlugin;
+
+impl Plugin for SpawnCommandsPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_console_command::<SpawnCommand, _>(spawn_command)
+            .add_console_command::<DespawnCommand, _>(despawn_command);
+    }
+}
+
+/// Spawns an entity of the specified type
+#[derive(Parser, ConsoleCommand)]
+#[command(name = "spawn")]
+struct SpawnCommand {
+    /// Type of entity to spawn
+    entity_type: String,
+    /// Optional name for the entity
+    #[arg(short, long)]
+    name: Option<String>,
+}
+
+fn spawn_command(mut log: ConsoleCommand<SpawnCommand>, mut commands: Commands) {
+    if let Some(Ok(SpawnCommand { entity_type, name })) = log.take() {
+        match entity_type.as_str() {
+            "something" => {
+                let entity_name = name.clone().unwrap_or_else(|| entity_type.clone());
+                let entity = commands.spawn(
+                    Name::new(entity_name),
+                ).id();
+                log.reply_ok(format!("Spawned new {} with entity id: {:?}", entity_type, entity));
+            }
+            _ => {
+                log.reply_failed(format!("Unknown entity type: {}", entity_type));
+            }
+        }
+    }
+}
+
+#[derive(Parser, ConsoleCommand)]
+#[command(name = "despawn")]
+struct DespawnCommand {
+    /// Entity to remove
+    entity_id: u32,
+}
+
+fn despawn_command(mut log: ConsoleCommand<DespawnCommand>, mut commands: Commands) {
+    if let Some(Ok(DespawnCommand { entity_id })) = log.take() {
+        commands
+            .entity(Entity::from_raw(entity_id))
+            .despawn_recursive();
+        log.ok();
+    }
+}

--- a/src/dev/debug_ui.rs
+++ b/src/dev/debug_ui.rs
@@ -1,0 +1,20 @@
+use bevy::{
+    dev_tools::ui_debug_overlay::{DebugUiPlugin, UiDebugOptions},
+    input::common_conditions::input_just_pressed,
+    prelude::*,
+};
+
+const TOGGLE_KEY: KeyCode = KeyCode::F4;
+
+pub(super) fn plugin(app: &mut App) {
+    app.add_plugins((
+        DebugUiPlugin,
+    )).add_systems(
+        Update,
+        toggle_debug_ui.run_if(input_just_pressed(TOGGLE_KEY)),
+    );
+}
+
+fn toggle_debug_ui(mut options: ResMut<UiDebugOptions>) {
+    options.toggle();
+}

--- a/src/dev/mod.rs
+++ b/src/dev/mod.rs
@@ -1,0 +1,9 @@
+mod console;
+mod debug_ui;
+
+use bevy::prelude::*;
+
+pub(super) fn plugin(app: &mut App) {
+    console::plugin(app);
+    debug_ui::plugin(app);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
+mod camera;
+
+#[cfg(feature = "dev")]
+mod dev;
 
 use bevy::{
     prelude::*,
     asset::AssetMetaCheck,
-    window::{EnabledButtons, WindowTheme},
 };
 
 pub struct AppPlugin;
@@ -21,22 +24,24 @@ impl Plugin for AppPlugin {
                 })
                 .set(WindowPlugin {
                     primary_window: Window {
-                        title: "🕳️".to_string(),
+                        title: "s p a c e t i m e".to_string(),
                         canvas: Some("#bevy".to_string()),
                         fit_canvas_to_parent: true,
                         prevent_default_event_handling: true,
-                        resolution: (1640., 1019.).into(),
-                        resizable: false,
-                        window_theme: Some(WindowTheme::Dark),
-                        enabled_buttons: EnabledButtons {
-                            maximize: false,
-                            ..Default::default()
-                        },
                         ..default()
                     }
                     .into(),
                     ..default()
                 })
+                .build()
+                .disable::<bevy::log::LogPlugin>(), // Logging is configured by the dev plugin
         );
+
+        app.add_plugins((
+            camera::plugin,
+        ));
+
+        #[cfg(feature = "dev")]
+        app.add_plugins(dev::plugin);
     }
 }


### PR DESCRIPTION
- I added a built-in CLI and logging console via `bevy_console`. This tools has been useful in other projects, so I set it up here.
- I turned on default Bevy features again.
  - There are a couple features that I don't want (like audio) but there are way more that I do want.
  - This will bloat the binary size and compile times, but now is not the time to worry about that.